### PR TITLE
Add ability to fix errors caught by lint (run npm run lint:fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "npm run lint",
     "start": "node server.js",
     "lint": "semistandard --verbose | snazzy",
+    "lint:fix": "semistandard --fix",
     "format": "prettier-semi --write '**/*.js'",
     "watch": "nodemon server.js"
   },


### PR DESCRIPTION
I asked teachers.  Got the above.  run "npm run lint:fix" to fix errors caught by lint.